### PR TITLE
fix: update p-event to v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"pool"
 	],
 	"dependencies": {
-		"p-event": "^6.0.0",
+		"p-event": "^7.1.0",
 		"type-fest": "^4.6.0",
 		"web-worker": "^1.5.0"
 	},


### PR DESCRIPTION
Bumps the `p-event` version to `^7.1.0` for smaller bundle sizes when deps depend on different version of `p-event`.